### PR TITLE
[ci skip] Fix spelling errors in NBodySimulator.jl

### DIFF
--- a/test/custom_potential_test.jl
+++ b/test/custom_potential_test.jl
@@ -11,7 +11,7 @@ function get_accelerating_function(p::CustomPotentialParameters,
     end
 end
 
-@testset "A sysem with custom potential" begin
+@testset "A system with custom potential" begin
     m1 = 1.0
     m2 = 1.0
 

--- a/test/gravitational_test.jl
+++ b/test/gravitational_test.jl
@@ -35,7 +35,7 @@ using OrdinaryDiffEq
             @test e_kin≈kinetic_energy(sim_result, t1) atol=ε
         end
 
-        @testset "Using convertion into SecondOrderODEProblem" begin
+        @testset "Using conversion into SecondOrderODEProblem" begin
             sim_result = run_simulation(simulation, DPRKN6())
             solution_simo_3_2nd = sim_result.solution
             ε = 0.001


### PR DESCRIPTION
## Summary

This PR fixes spelling errors found by the typos spell checker.

## Changes Made

- convertion -> conversion in test/gravitational_test.jl
- sysem -> system in test/custom_potential_test.jl


## Notes

-  included to avoid unnecessary CI runs for spelling fixes
- All changes are simple typo corrections that don't affect functionality
- Changes were made using automated spell checking with manual review